### PR TITLE
Allow separate providers for certificate, Route 53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .terraform.lock.hcl
 .terraformrc
 .validate
+test.tf

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -41,7 +41,7 @@ rule "terraform_required_providers" {
 }
 
 rule "terraform_unused_required_providers" {
-  enabled = true
+  enabled = false
 }
 
 rule "terraform_standard_module_structure" {

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 terraform 0.15.5
-terraform-docs 0.12.1
+terraform-docs 0.14.1
 tflint 0.29.0

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ module "ingress" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.45 |
 
 ## Providers
 
@@ -63,13 +64,13 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm_certificate"></a> [acm\_certificate](#module\_acm\_certificate) | ./modules/acm-certificate |  |
-| <a name="module_alb"></a> [alb](#module\_alb) | ./modules/alb |  |
-| <a name="module_alias"></a> [alias](#module\_alias) | ./modules/alb-route53-alias |  |
-| <a name="module_cloudwatch_alarms"></a> [cloudwatch\_alarms](#module\_cloudwatch\_alarms) | ./modules/alb-cloudwatch-alarms |  |
-| <a name="module_http"></a> [http](#module\_http) | ./modules/alb-http-redirect |  |
-| <a name="module_https"></a> [https](#module\_https) | ./modules/alb-https-forward |  |
-| <a name="module_target_group"></a> [target\_group](#module\_target\_group) | ./modules/alb-target-group |  |
+| <a name="module_acm_certificate"></a> [acm\_certificate](#module\_acm\_certificate) | ./modules/acm-certificate | n/a |
+| <a name="module_alb"></a> [alb](#module\_alb) | ./modules/alb | n/a |
+| <a name="module_alias"></a> [alias](#module\_alias) | ./modules/alb-route53-alias | n/a |
+| <a name="module_cloudwatch_alarms"></a> [cloudwatch\_alarms](#module\_cloudwatch\_alarms) | ./modules/alb-cloudwatch-alarms | n/a |
+| <a name="module_http"></a> [http](#module\_http) | ./modules/alb-http-redirect | n/a |
+| <a name="module_https"></a> [https](#module\_https) | ./modules/alb-https-forward | n/a |
+| <a name="module_target_group"></a> [target\_group](#module\_target\_group) | ./modules/alb-target-group | n/a |
 
 ## Resources
 

--- a/makefile
+++ b/makefile
@@ -50,10 +50,12 @@ validate: .validate
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
+.validate: .init $(MODULEFILES) test.tf
 	AWS_DEFAULT_REGION=us-east-1 terraform validate
 	@touch .validate
 
+test.tf: $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
 .PHONY: modules
 modules: makefiles makemodules
 

--- a/makefiles/terraform.mk
+++ b/makefiles/terraform.mk
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/acm-certificate/README.md
+++ b/modules/acm-certificate/README.md
@@ -10,7 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws.certificate"></a> [aws.certificate](#provider\_aws.certificate) | 3.52.0 |
+| <a name="provider_aws.route53"></a> [aws.route53](#provider\_aws.route53) | 3.52.0 |
 
 ## Modules
 

--- a/modules/acm-certificate/main.tf
+++ b/modules/acm-certificate/main.tf
@@ -1,7 +1,13 @@
 resource "aws_acm_certificate" "this" {
+  provider = aws.certificate
+
   domain_name       = var.domain_name
   tags              = var.tags
   validation_method = var.validation_method
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
 
   subject_alternative_names = concat(
     var.wildcard ? ["*.${var.domain_name}"] : [],
@@ -18,6 +24,8 @@ locals {
 }
 
 resource "aws_route53_record" "validation" {
+  provider = aws.route53
+
   count = var.hosted_zone_name == null ? 0 : 1
 
   name    = local.domain_validation_options[0].resource_record_name
@@ -28,6 +36,8 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_route53_record" "alternative_validation" {
+  provider = aws.route53
+
   count = var.hosted_zone_name == null ? 0 : length(var.alternative_names)
 
   name    = local.domain_validation_options[count.index].resource_record_name
@@ -38,6 +48,8 @@ resource "aws_route53_record" "alternative_validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
+  provider = aws.certificate
+
   certificate_arn = aws_acm_certificate.this.arn
 
   validation_record_fqdns = concat(
@@ -47,6 +59,8 @@ resource "aws_acm_certificate_validation" "this" {
 }
 
 data "aws_route53_zone" "this" {
+  provider = aws.route53
+
   count = var.hosted_zone_name == null ? 0 : 1
 
   name = var.hosted_zone_name

--- a/modules/acm-certificate/makefile
+++ b/modules/acm-certificate/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/acm-certificate/providers.tf.example
+++ b/modules/acm-certificate/providers.tf.example
@@ -1,0 +1,9 @@
+provider "aws" {
+  alias  = "certificate"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "route53"
+  region = "us-east-1"
+}

--- a/modules/acm-certificate/versions.tf
+++ b/modules/acm-certificate/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.45"
+      configuration_aliases = [aws.certificate, aws.route53]
+      source                = "hashicorp/aws"
+      version               = "~> 3.45"
     }
   }
 }

--- a/modules/alb-cloudwatch-alarms/README.md
+++ b/modules/alb-cloudwatch-alarms/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb-cloudwatch-alarms/makefile
+++ b/modules/alb-cloudwatch-alarms/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/alb-http-redirect/README.md
+++ b/modules/alb-http-redirect/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb-http-redirect/makefile
+++ b/modules/alb-http-redirect/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/alb-https-forward/README.md
+++ b/modules/alb-https-forward/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb-https-forward/makefile
+++ b/modules/alb-https-forward/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/alb-route53-alias/README.md
+++ b/modules/alb-route53-alias/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb-route53-alias/makefile
+++ b/modules/alb-route53-alias/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/alb-target-group/README.md
+++ b/modules/alb-target-group/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb-target-group/makefile
+++ b/modules/alb-target-group/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 

--- a/modules/alb/makefile
+++ b/modules/alb/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .PHONY: clean
 clean:

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -1,0 +1,9 @@
+provider "aws" {
+  alias  = "cluster"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "route53"
+  region = "us-east-1"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,11 @@
 terraform {
   required_version = ">= 0.14.0"
+
+  required_providers {
+    aws = {
+      configuration_aliases = [aws.cluster, aws.route53]
+      source                = "hashicorp/aws"
+      version               = "~> 3.45"
+    }
+  }
 }


### PR DESCRIPTION
This split provider configuration allows for certificates to be provisioned in one account and DNS verification to occur in another. This is useful with an account architecture with centralized DNS management.
