### PR TITLE
Optionally accept legacy target group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ module "ingress" {
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.52.0 |
 
 ## Modules
 
@@ -74,7 +76,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_lb_target_group.legacy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 
 ## Inputs
 
@@ -89,6 +93,7 @@ No resources.
 | <a name="input_failure_threshold"></a> [failure\_threshold](#input\_failure\_threshold) | Percentage of failed requests considered an anomaly | `number` | `5` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Hosted zone for AWS Route53 | `string` | `null` | no |
 | <a name="input_issue_certificates"></a> [issue\_certificates](#input\_issue\_certificates) | Set to false to disable creation of ACM certificates | `bool` | `true` | no |
+| <a name="input_legacy_target_group_names"></a> [legacy\_target\_group\_names](#input\_legacy\_target\_group\_names) | Names of legacy target groups which should be included | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this load balancer | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
 | <a name="input_primary_domain_name"></a> [primary\_domain\_name](#input\_primary\_domain\_name) | Primary domain name for the ALB | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -73,11 +73,20 @@ module "target_group" {
   vpc               = var.vpc
 }
 
+data "aws_lb_target_group" "legacy" {
+  for_each = toset(var.legacy_target_group_names)
+
+  name = each.value
+}
+
 locals {
   domain_names = concat([var.primary_domain_name], var.alternative_domain_names)
 
   target_groups = zipmap(
-    keys(var.target_groups),
-    values(module.target_group).*.instance
+    concat(keys(var.target_groups), keys(data.aws_lb_target_group.legacy)),
+    concat(
+      values(module.target_group).*.instance,
+      values(data.aws_lb_target_group.legacy)
+    )
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "issue_certificates" {
   default     = true
 }
 
+variable "legacy_target_group_names" {
+  description = "Names of legacy target groups which should be included"
+  type        = list(string)
+  default     = []
+}
+
 variable "name" {
   description = "Name for this load balancer"
   type        = string


### PR DESCRIPTION
If we want to slow migrate from existing target groups, we need to add those target groups to the load balancer without creating them.
