### PR TITLE
Accept ID strings for VPC, subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ module "ingress" {
   hosted_zone_name         = "example.com"
   name                     = "example-ingress"
   primary_domain_name      = "www.example.com"
-  subnets                  = data.aws_subnet.public
-  vpc                      = data.aws_vpc.example
+  subnet_ids               = data.aws_subnet_ids.public.ids
+  vpc_id                   = data.aws_vpc.example.id
 
   target_groups = {
     canary = {
@@ -98,12 +98,12 @@ module "ingress" {
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
 | <a name="input_primary_domain_name"></a> [primary\_domain\_name](#input\_primary\_domain\_name) | Primary domain name for the ALB | `string` | n/a | yes |
 | <a name="input_slow_response_threshold"></a> [slow\_response\_threshold](#input\_slow\_response\_threshold) | Response time considered extremely slow | `number` | `10` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets for this load balancer | `map(object({ id = string }))` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets for this load balancer | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |
 | <a name="input_target_group_weights"></a> [target\_group\_weights](#input\_target\_group\_weights) | Weight for each target group (defaults to 100) | `map(number)` | `{}` | no |
 | <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | Target groups to which this rule should forward | <pre>map(object({<br>    health_check_path = string,<br>    health_check_port = number,<br>    name              = string<br>  }))</pre> | n/a | yes |
 | <a name="input_validate_certificates"></a> [validate\_certificates](#input\_validate\_certificates) | Set to false to disable validation via Route 53 | `bool` | `true` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | VPC for the ALB | `object({ id = string })` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC for the ALB | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -5,9 +5,9 @@ module "alb" {
   description = var.description
   name        = var.name
   namespace   = var.namespace
-  subnets     = var.subnets
+  subnet_ids  = var.subnet_ids
   tags        = var.tags
-  vpc         = var.vpc
+  vpc_id      = var.vpc_id
 }
 
 module "cloudwatch_alarms" {
@@ -70,7 +70,7 @@ module "target_group" {
   health_check_path = each.value.health_check_path
   health_check_port = each.value.health_check_port
   name              = each.value.name
-  vpc               = var.vpc
+  vpc_id            = var.vpc_id
 }
 
 data "aws_lb_target_group" "legacy" {

--- a/modules/alb-target-group/README.md
+++ b/modules/alb-target-group/README.md
@@ -31,7 +31,7 @@ No modules.
 | <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port for health check | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for this target group | `string` | n/a | yes |
 | <a name="input_target_type"></a> [target\_type](#input\_target\_type) | Target group (default: ip) | `string` | `"ip"` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | VPC for the target group | `object({ id = string })` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC for the target group | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/alb-target-group/main.tf
+++ b/modules/alb-target-group/main.tf
@@ -3,7 +3,7 @@ resource "aws_alb_target_group" "this" {
   port        = 443
   protocol    = "HTTPS"
   target_type = var.target_type
-  vpc_id      = var.vpc.id
+  vpc_id      = var.vpc_id
 
   health_check {
     path = var.health_check_path

--- a/modules/alb-target-group/variables.tf
+++ b/modules/alb-target-group/variables.tf
@@ -25,7 +25,7 @@ variable "target_type" {
   default     = "ip"
 }
 
-variable "vpc" {
-  type        = object({ id = string })
+variable "vpc_id" {
+  type        = string
   description = "VPC for the target group"
 }

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -33,9 +33,9 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Human description for this load balancer | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for this load balancer | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets for this load balancer | `map(object({ id = string }))` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets for this load balancer | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | VPC for the ALB | `object({ id = string })` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC for the ALB | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,7 +1,7 @@
 resource "aws_alb" "this" {
   name            = join("-", concat(var.namespace, [var.name]))
   security_groups = [aws_security_group.this.id]
-  subnets         = values(var.subnets).*.id
+  subnets         = var.subnet_ids
   tags            = var.tags
 }
 
@@ -9,7 +9,7 @@ resource "aws_security_group" "this" {
   description = var.description
   name        = join("-", concat(var.namespace, [var.name]))
   tags        = var.tags
-  vpc_id      = var.vpc.id
+  vpc_id      = var.vpc_id
 }
 
 resource "aws_security_group_rule" "aws_alb_http_ingress" {

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -14,8 +14,8 @@ variable "namespace" {
   default     = []
 }
 
-variable "subnets" {
-  type        = map(object({ id = string }))
+variable "subnet_ids" {
+  type        = list(string)
   description = "Subnets for this load balancer"
 }
 
@@ -25,7 +25,7 @@ variable "tags" {
   default     = {}
 }
 
-variable "vpc" {
-  type        = object({ id = string })
+variable "vpc_id" {
+  type        = string
   description = "VPC for the ALB"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,8 +79,8 @@ variable "slow_response_threshold" {
   description = "Response time considered extremely slow"
 }
 
-variable "subnets" {
-  type        = map(object({ id = string }))
+variable "subnet_ids" {
+  type        = list(string)
   description = "Subnets for this load balancer"
 }
 
@@ -112,7 +112,7 @@ variable "validate_certificates" {
   default     = true
 }
 
-variable "vpc" {
-  type        = object({ id = string })
+variable "vpc_id" {
+  type        = string
   description = "VPC for the ALB"
 }


### PR DESCRIPTION
We only need the IDs for these values rather than the entire VPC and subnet objects. Accepting the IDs means we can pass them directly when we have the ID without using a data resource to look up the object first.
