### PR TITLE
Use most recent ACM certificate

### DIFF
--- a/modules/alb-https-forward/main.tf
+++ b/modules/alb-https-forward/main.tf
@@ -45,8 +45,9 @@ resource "aws_alb_listener_certificate" "this" {
 }
 
 data "aws_acm_certificate" "acm_certificate" {
-  domain   = var.primary_domain_name
-  statuses = ["ISSUED"]
+  domain      = var.primary_domain_name
+  most_recent = true
+  statuses    = ["ISSUED"]
 }
 
 data "aws_acm_certificate" "alternatives" {


### PR DESCRIPTION
If more than one ACM certificate is available for the primary domain, use the most recent certificate rather than failing.
