### PR TITLE
Allow overriding the certificate domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "ingress" {
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topics or other actions to invoke for alarms | `list(object({ arn = string }))` | `[]` | no |
 | <a name="input_alarm_evaluation_minutes"></a> [alarm\_evaluation\_minutes](#input\_alarm\_evaluation\_minutes) | Number of minutes of alarm state until triggering an alarm | `number` | `2` | no |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
+| <a name="input_certificate_domain_name"></a> [certificate\_domain\_name](#input\_certificate\_domain\_name) | Override the domain name for the ACM certificate (defaults to primary domain) | `string` | `null` | no |
 | <a name="input_create_aliases"></a> [create\_aliases](#input\_create\_aliases) | Set to false to disable creation of Route 53 aliases | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Human description for this load balancer | `string` | n/a | yes |
 | <a name="input_enable_stickiness"></a> [enable\_stickiness](#input\_enable\_stickiness) | Set to true to use a cookie for load balancer stickiness | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "https" {
 
   alb                      = module.alb.instance
   alternative_domain_names = var.alternative_domain_names
-  primary_domain_name      = var.primary_domain_name
+  certificate_domain_name  = local.certificate_domain_name
   target_groups            = local.target_groups
   target_group_weights     = var.target_group_weights
 
@@ -80,6 +80,11 @@ data "aws_lb_target_group" "legacy" {
 }
 
 locals {
+  certificate_domain_name = coalesce(
+    var.certificate_domain_name,
+    var.primary_domain_name
+  )
+
   domain_names = concat([var.primary_domain_name], var.alternative_domain_names)
 
   target_groups = zipmap(

--- a/modules/alb-https-forward/README.md
+++ b/modules/alb-https-forward/README.md
@@ -31,7 +31,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb"></a> [alb](#input\_alb) | The ALB for which a listener should be created | `object({ arn = string })` | n/a | yes |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
-| <a name="input_primary_domain_name"></a> [primary\_domain\_name](#input\_primary\_domain\_name) | Primary domain name for the ALB | `string` | n/a | yes |
+| <a name="input_certificate_domain_name"></a> [certificate\_domain\_name](#input\_certificate\_domain\_name) | Domain name for which an ACM certificate can be found | `string` | n/a | yes |
 | <a name="input_target_group_weights"></a> [target\_group\_weights](#input\_target\_group\_weights) | Weight for each target group (defaults to 100) | `map(number)` | `{}` | no |
 | <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | The target groups to which this listener should forward | `map(object({ arn = string }))` | n/a | yes |
 

--- a/modules/alb-https-forward/main.tf
+++ b/modules/alb-https-forward/main.tf
@@ -45,7 +45,7 @@ resource "aws_alb_listener_certificate" "this" {
 }
 
 data "aws_acm_certificate" "acm_certificate" {
-  domain      = var.primary_domain_name
+  domain      = var.certificate_domain_name
   most_recent = true
   statuses    = ["ISSUED"]
 }

--- a/modules/alb-https-forward/variables.tf
+++ b/modules/alb-https-forward/variables.tf
@@ -9,9 +9,9 @@ variable "alternative_domain_names" {
   description = "Alternative domain names for the ALB"
 }
 
-variable "primary_domain_name" {
+variable "certificate_domain_name" {
   type        = string
-  description = "Primary domain name for the ALB"
+  description = "Domain name for which an ACM certificate can be found"
 }
 
 variable "target_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "alternative_domain_names" {
   description = "Alternative domain names for the ALB"
 }
 
+variable "certificate_domain_name" {
+  type        = string
+  default     = null
+  description = "Override the domain name for the ACM certificate (defaults to primary domain)"
+}
+
 variable "create_aliases" {
   description = "Set to false to disable creation of Route 53 aliases"
   type        = bool


### PR DESCRIPTION
If the certificate already exists and has a different primary domain, there is no way to use the existing certificate. This adds a parameter to override the domain name at which the certificate is found so that existing certificates can be provided.
