### PR TITLE
Allow overwriting existing domain entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ module "ingress" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topics or other actions to invoke for alarms | `list(object({ arn = string }))` | `[]` | no |
 | <a name="input_alarm_evaluation_minutes"></a> [alarm\_evaluation\_minutes](#input\_alarm\_evaluation\_minutes) | Number of minutes of alarm state until triggering an alarm | `number` | `2` | no |
+| <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow overwriting of existing DNS records | `bool` | `false` | no |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
 | <a name="input_certificate_domain_name"></a> [certificate\_domain\_name](#input\_certificate\_domain\_name) | Override the domain name for the ACM certificate (defaults to primary domain) | `string` | `null` | no |
 | <a name="input_create_aliases"></a> [create\_aliases](#input\_create\_aliases) | Set to false to disable creation of Route 53 aliases | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ module "acm_certificate" {
   providers = { aws.certificate = aws.cluster, aws.route53 = aws.route53 }
   source    = "./modules/acm-certificate"
 
+  allow_overwrite  = var.allow_overwrite
   domain_name      = each.value
   hosted_zone_name = var.validate_certificates ? var.hosted_zone_name : null
 }
@@ -57,6 +58,7 @@ module "alias" {
   source    = "./modules/alb-route53-alias"
 
   alb              = module.alb.instance
+  allow_overwrite  = var.allow_overwrite
   hosted_zone_name = var.hosted_zone_name
   name             = each.value
 }

--- a/modules/acm-certificate/README.md
+++ b/modules/acm-certificate/README.md
@@ -31,6 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow overwriting of existing DNS records | `bool` | `false` | no |
 | <a name="input_alternative_names"></a> [alternative\_names](#input\_alternative\_names) | Other domains which should be included in the certificate | `list(string)` | `[]` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for which an SSL certificate should be created | `string` | n/a | yes |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Zone for AWS Route53 for verifying certificates | `string` | `null` | no |

--- a/modules/acm-certificate/main.tf
+++ b/modules/acm-certificate/main.tf
@@ -28,11 +28,12 @@ resource "aws_route53_record" "validation" {
 
   count = var.hosted_zone_name == null ? 0 : 1
 
-  name    = local.domain_validation_options[0].resource_record_name
-  records = [local.domain_validation_options[0].resource_record_value]
-  ttl     = 3600
-  type    = local.domain_validation_options[0].resource_record_type
-  zone_id = join("", data.aws_route53_zone.this.*.zone_id)
+  allow_overwrite = var.allow_overwrite
+  name            = local.domain_validation_options[0].resource_record_name
+  records         = [local.domain_validation_options[0].resource_record_value]
+  ttl             = 3600
+  type            = local.domain_validation_options[0].resource_record_type
+  zone_id         = join("", data.aws_route53_zone.this.*.zone_id)
 }
 
 resource "aws_route53_record" "alternative_validation" {
@@ -40,11 +41,12 @@ resource "aws_route53_record" "alternative_validation" {
 
   count = var.hosted_zone_name == null ? 0 : length(var.alternative_names)
 
-  name    = local.domain_validation_options[count.index].resource_record_name
-  records = [local.domain_validation_options[count.index].resource_record_value]
-  ttl     = 3600
-  type    = local.domain_validation_options[count.index].resource_record_type
-  zone_id = join("", data.aws_route53_zone.this.*.zone_id)
+  allow_overwrite = var.allow_overwrite
+  name            = local.domain_validation_options[count.index].resource_record_name
+  records         = [local.domain_validation_options[count.index].resource_record_value]
+  ttl             = 3600
+  type            = local.domain_validation_options[count.index].resource_record_type
+  zone_id         = join("", data.aws_route53_zone.this.*.zone_id)
 }
 
 resource "aws_acm_certificate_validation" "this" {

--- a/modules/acm-certificate/variables.tf
+++ b/modules/acm-certificate/variables.tf
@@ -1,3 +1,9 @@
+variable "allow_overwrite" {
+  type        = bool
+  default     = false
+  description = "Allow overwriting of existing DNS records"
+}
+
 variable "alternative_names" {
   type        = list(string)
   description = "Other domains which should be included in the certificate"

--- a/modules/alb-route53-alias/README.md
+++ b/modules/alb-route53-alias/README.md
@@ -28,6 +28,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb"></a> [alb](#input\_alb) | ALB for which an alias should be created | `object({ dns_name = string, zone_id = string })` | n/a | yes |
+| <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow overwriting of existing DNS records | `bool` | `false` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Hosted zone for AWS Route53 | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Route 53 alias (example: www) | `string` | n/a | yes |
 

--- a/modules/alb-route53-alias/main.tf
+++ b/modules/alb-route53-alias/main.tf
@@ -1,9 +1,10 @@
 resource "aws_route53_record" "load_balancer" {
   for_each = toset(var.hosted_zone_name == null ? [] : [var.hosted_zone_name])
 
-  zone_id = data.aws_route53_zone.this[each.value].zone_id
-  type    = "A"
-  name    = var.name
+  allow_overwrite = var.allow_overwrite
+  name            = var.name
+  type            = "A"
+  zone_id         = data.aws_route53_zone.this[each.value].zone_id
 
   alias {
     evaluate_target_health = true

--- a/modules/alb-route53-alias/variables.tf
+++ b/modules/alb-route53-alias/variables.tf
@@ -3,6 +3,12 @@ variable "alb" {
   type        = object({ dns_name = string, zone_id = string })
 }
 
+variable "allow_overwrite" {
+  type        = bool
+  default     = false
+  description = "Allow overwriting of existing DNS records"
+}
+
 variable "name" {
   description = "Name of the Route 53 alias (example: www)"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "alarm_evaluation_minutes" {
   description = "Number of minutes of alarm state until triggering an alarm"
 }
 
+variable "allow_overwrite" {
+  type        = bool
+  default     = false
+  description = "Allow overwriting of existing DNS records"
+}
+
 variable "alternative_domain_names" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
This makes it easier to migrate an existing hosted zone without importing all the domain entries individually.
