### PR TITLE
Use most recent ACM certificate

### DIFF
--- a/modules/alb-https-forward/main.tf
+++ b/modules/alb-https-forward/main.tf
@@ -53,6 +53,7 @@ data "aws_acm_certificate" "acm_certificate" {
 data "aws_acm_certificate" "alternatives" {
   for_each = toset(var.alternative_domain_names)
 
-  domain   = each.value
-  statuses = ["ISSUED"]
+  domain      = each.value
+  most_recent = true
+  statuses    = ["ISSUED"]
 }


### PR DESCRIPTION
If more than one certificate is available for a domain, use the latest rather than failing.

This is already set for the primary domain, but not for alternatives.
