### PR TITLE
Create security group before destroy

### DIFF
--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -10,6 +10,11 @@ resource "aws_security_group" "this" {
   name        = join("-", concat(var.namespace, [var.name]))
   tags        = var.tags
   vpc_id      = var.vpc_id
+
+  lifecycle {
+    # You can't remove the last security group
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "aws_alb_http_ingress" {


### PR DESCRIPTION
You can't remove the last security group and you can't delete it while it's attached, so if you're re-creating the security group (after, for example, a description change) you must create the new one before destroying the old one.
