### PR TITLE
Fix validation records for alternative ACM domains

### DIFF
--- a/modules/acm-certificate/main.tf
+++ b/modules/acm-certificate/main.tf
@@ -42,10 +42,10 @@ resource "aws_route53_record" "alternative_validation" {
   count = var.hosted_zone_name == null ? 0 : length(var.alternative_names)
 
   allow_overwrite = var.allow_overwrite
-  name            = local.domain_validation_options[count.index].resource_record_name
-  records         = [local.domain_validation_options[count.index].resource_record_value]
+  name            = local.domain_validation_options[count.index + 1].resource_record_name
+  records         = [local.domain_validation_options[count.index + 1].resource_record_value]
   ttl             = 3600
-  type            = local.domain_validation_options[count.index].resource_record_type
+  type            = local.domain_validation_options[count.index + 1].resource_record_type
   zone_id         = join("", data.aws_route53_zone.this.*.zone_id)
 }
 


### PR DESCRIPTION
This was attempting to reuse the same record as the primary domain for the first alternative domain when verifying ACM certificates. This offsets the index for alternative names so that they get the correct verification record.
