### PR TITLE
Remove namespace argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ module "ingress" {
 | <a name="input_issue_certificates"></a> [issue\_certificates](#input\_issue\_certificates) | Set to false to disable creation of ACM certificates | `bool` | `true` | no |
 | <a name="input_legacy_target_group_names"></a> [legacy\_target\_group\_names](#input\_legacy\_target\_group\_names) | Names of legacy target groups which should be included | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this load balancer | `string` | n/a | yes |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
 | <a name="input_primary_domain_name"></a> [primary\_domain\_name](#input\_primary\_domain\_name) | Primary domain name for the ALB | `string` | n/a | yes |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name for the load balancer security group; defaults to name | `string` | `null` | no |
 | <a name="input_slow_response_threshold"></a> [slow\_response\_threshold](#input\_slow\_response\_threshold) | Response time considered extremely slow | `number` | `10` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets for this load balancer | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,12 @@ module "alb" {
   providers = { aws = aws.cluster }
   source    = "./modules/alb"
 
-  description = var.description
-  name        = var.name
-  namespace   = var.namespace
-  subnet_ids  = var.subnet_ids
-  tags        = var.tags
-  vpc_id      = var.vpc_id
+  description         = var.description
+  name                = var.name
+  security_group_name = var.security_group_name
+  subnet_ids          = var.subnet_ids
+  tags                = var.tags
+  vpc_id              = var.vpc_id
 }
 
 module "cloudwatch_alarms" {

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -32,7 +32,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | Human description for this load balancer | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for this load balancer | `string` | n/a | yes |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name for the load balancer security group; defaults to name | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets for this load balancer | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC for the ALB | `string` | n/a | yes |

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,5 +1,5 @@
 resource "aws_alb" "this" {
-  name            = join("-", concat(var.namespace, [var.name]))
+  name            = var.name
   security_groups = [aws_security_group.this.id]
   subnets         = var.subnet_ids
   tags            = var.tags
@@ -7,7 +7,7 @@ resource "aws_alb" "this" {
 
 resource "aws_security_group" "this" {
   description = var.description
-  name        = join("-", concat(var.namespace, [var.name]))
+  name        = coalesce(var.security_group_name, var.name)
   tags        = var.tags
   vpc_id      = var.vpc_id
 

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -8,10 +8,10 @@ variable "name" {
   type        = string
 }
 
-variable "namespace" {
-  description = "Prefix to apply to created resources"
-  type        = list(string)
-  default     = []
+variable "security_group_name" {
+  type        = string
+  description = "Name for the load balancer security group; defaults to name"
+  default     = null
 }
 
 variable "subnet_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -86,15 +86,15 @@ variable "name" {
   type        = string
 }
 
-variable "namespace" {
-  description = "Prefix to apply to created resources"
-  type        = list(string)
-  default     = []
-}
-
 variable "primary_domain_name" {
   type        = string
   description = "Primary domain name for the ALB"
+}
+
+variable "security_group_name" {
+  type        = string
+  description = "Name for the load balancer security group; defaults to name"
+  default     = null
 }
 
 variable "slow_response_threshold" {


### PR DESCRIPTION
We've stopped using this argument in newer modules. We prefer to specify the exact name for clarity.
