### PR TITLE
Improve certificate management

### DIFF
--- a/modules/alb-route53-alias/README.md
+++ b/modules/alb-route53-alias/README.md
@@ -27,7 +27,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alb"></a> [alb](#input\_alb) | ALB for which an alias should be created | `object({ dns_name = string, zone_id = string })` | n/a | yes |
+| <a name="input_alb_dns_name"></a> [alb\_dns\_name](#input\_alb\_dns\_name) | DNS name for the ALB for which an alias should be created | `string` | n/a | yes |
+| <a name="input_alb_zone_id"></a> [alb\_zone\_id](#input\_alb\_zone\_id) | Route53 zone for the ALB for which an alias should be created | `string` | n/a | yes |
 | <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow overwriting of existing DNS records | `bool` | `false` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Hosted zone for AWS Route53 | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Route 53 alias (example: www) | `string` | n/a | yes |

--- a/modules/alb-route53-alias/main.tf
+++ b/modules/alb-route53-alias/main.tf
@@ -8,8 +8,8 @@ resource "aws_route53_record" "load_balancer" {
 
   alias {
     evaluate_target_health = true
-    name                   = var.alb.dns_name
-    zone_id                = var.alb.zone_id
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
   }
 }
 

--- a/modules/alb-route53-alias/variables.tf
+++ b/modules/alb-route53-alias/variables.tf
@@ -1,6 +1,11 @@
-variable "alb" {
-  description = "ALB for which an alias should be created"
-  type        = object({ dns_name = string, zone_id = string })
+variable "alb_dns_name" {
+  description = "DNS name for the ALB for which an alias should be created"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "Route53 zone for the ALB for which an alias should be created"
+  type        = string
 }
 
 variable "allow_overwrite" {

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -41,6 +41,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNS name of the created application load balancer |
 | <a name="output_instance"></a> [instance](#output\_instance) | The created AWS application load balancer |
 | <a name="output_security_group"></a> [security\_group](#output\_security\_group) | The security group created for this load balancer |
+| <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Route53 zone of the created application load balancer |
 <!-- END_TF_DOCS -->

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,3 +1,8 @@
+output "dns_name" {
+  description = "DNS name of the created application load balancer"
+  value       = aws_alb.this.dns_name
+}
+
 output "instance" {
   description = "The created AWS application load balancer"
   value       = aws_alb.this
@@ -7,3 +12,9 @@ output "security_group" {
   description = "The security group created for this load balancer"
   value       = aws_security_group.this
 }
+
+output "zone_id" {
+  description = "Route53 zone of the created application load balancer"
+  value       = aws_alb.this.zone_id
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "dns_name" {
+  description = "DNS name of the created application load balancer"
+  value       = module.alb.dns_name
+}
+
 output "instance" {
   description = "The load balancer"
   value       = module.alb.instance
@@ -16,4 +21,9 @@ output "http_listener" {
 output "https_listener" {
   description = "The HTTPS listener"
   value       = module.https.instance
+}
+
+output "zone_id" {
+  description = "Route53 zone of the created application load balancer"
+  value       = module.alb.zone_id
 }

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -1,5 +1,5 @@
 provider "aws" {
-  alias  = "cluster"
+  alias  = "alb"
   region = "us-east-1"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "additional_hosted_zones" {
-  description = "Override the hosted zone for a particular domain"
-  type        = map(string)
-  default     = {}
-}
-
 variable "alarm_actions" {
   type        = list(object({ arn = string }))
   description = "SNS topics or other actions to invoke for alarms"
@@ -22,16 +16,10 @@ variable "allow_overwrite" {
   description = "Allow overwriting of existing DNS records"
 }
 
-variable "alternative_domain_names" {
+variable "attach_certificate_domains" {
+  description = "Additional existing certificates which should be attached"
   type        = list(string)
   default     = []
-  description = "Alternative domain names for the ALB"
-}
-
-variable "certificate_domain_name" {
-  type        = string
-  default     = null
-  description = "Override the domain name for the ACM certificate (defaults to primary domain)"
 }
 
 variable "certificate_types" {
@@ -40,10 +28,9 @@ variable "certificate_types" {
   default     = ["AMAZON_ISSUED"]
 }
 
-variable "create_aliases" {
-  description = "Set to false to disable creation of Route 53 aliases"
-  type        = bool
-  default     = true
+variable "create_domain_aliases" {
+  description = "List of domains for which alias records should be created"
+  type        = list(string)
 }
 
 variable "description" {
@@ -69,10 +56,10 @@ variable "hosted_zone_name" {
   default     = null
 }
 
-variable "issue_certificates" {
-  description = "Set to false to disable creation of ACM certificates"
-  type        = bool
-  default     = true
+variable "issue_certificate_domains" {
+  description = "List of domains for which certificates should be issued"
+  type        = list(string)
+  default     = []
 }
 
 variable "legacy_target_group_names" {
@@ -86,9 +73,9 @@ variable "name" {
   type        = string
 }
 
-variable "primary_domain_name" {
+variable "primary_certificate_domain" {
+  description = "Primary domain name for the load balancer certificate"
   type        = string
-  description = "Primary domain name for the ALB"
 }
 
 variable "security_group_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      configuration_aliases = [aws.cluster, aws.route53]
+      configuration_aliases = [aws.alb, aws.route53]
       source                = "hashicorp/aws"
       version               = "~> 4.0"
     }


### PR DESCRIPTION
Currently, the module does a good job of managing ACM certificates and aliases for single account setups when all hosted zones are in the same account. However, if hosted zones are spread out across accounts, you need to disable certificate and alias management entirely. This reworks the certificate management so it's possible to have a hybrid. It also tries to be less clever when figuring out alternative domain names for certificates, which should help prevent situations where it unnecessarily detaches certificates from the load balancer during changes.

- Clarify what's going to happen with each of the domain input variables by creating purpose-driven names like "issue_certificate_domains" and "create_domain_aliases."
- Make it possible to combine module-managed ACM certificates and aliases with externally created resources, so that the load balancer module itself can manage the primary SDLC domain and external certificates and aliases can be created separately.
- Provide better examples of multi-account and non-Route 53 setup.
